### PR TITLE
fix: only respond to app that sent message

### DIFF
--- a/src/actions/appInstance.js
+++ b/src/actions/appInstance.js
@@ -28,6 +28,7 @@ const getAppInstance = async (
 
     if (appInstance) {
       callback({
+        appInstanceId: id,
         type: GET_APP_INSTANCE_SUCCEEDED,
         payload: appInstance,
       });
@@ -42,6 +43,7 @@ const getAppInstance = async (
         GET_APP_INSTANCE_CHANNEL,
         async (event, response) => {
           callback({
+            appInstanceId: id,
             type: GET_APP_INSTANCE_SUCCEEDED,
             payload: response,
           });

--- a/src/actions/appInstanceResource.js
+++ b/src/actions/appInstanceResource.js
@@ -26,6 +26,8 @@ const getAppInstanceResources = async (
       GET_APP_INSTANCE_RESOURCES_CHANNEL,
       async (event, response) => {
         callback({
+          // have to include the appInstanceId to avoid broadcasting
+          appInstanceId,
           type: GET_APP_INSTANCE_RESOURCES_SUCCEEDED,
           payload: response,
         });
@@ -55,6 +57,8 @@ const postAppInstanceResource = async (
       POST_APP_INSTANCE_RESOURCE_CHANNEL,
       async (event, response) => {
         callback({
+          // have to include the appInstanceId to avoid broadcasting
+          appInstanceId,
           type: POST_APP_INSTANCE_RESOURCE_SUCCEEDED,
           payload: response,
         });
@@ -82,6 +86,7 @@ const patchAppInstanceResource = async (
       PATCH_APP_INSTANCE_RESOURCE_CHANNEL,
       async (event, response) => {
         callback({
+          appInstanceId,
           type: PATCH_APP_INSTANCE_RESOURCE_SUCCEEDED,
           payload: response,
         });

--- a/src/components/phase/PhaseApp.js
+++ b/src/components/phase/PhaseApp.js
@@ -54,6 +54,17 @@ class PhaseApp extends Component {
   }
 
   postMessage = data => {
+    // get component app instance id
+    const { appInstance } = this.props;
+    const { id: componentAppInstanceId } = appInstance || {};
+    // get app instance id in message
+    const { appInstanceId: messageAppInstanceId } = data;
+
+    // only post message to intended app instance
+    if (componentAppInstanceId !== messageAppInstanceId) {
+      return;
+    }
+
     const message = JSON.stringify(data);
 
     if (this.iframe.contentWindow.postMessage) {


### PR DESCRIPTION
We know the AppInstance ID of the app that sends a message to the
desktop. We now append this ID to the message. Therefore, when
responding to the message, we only send it if the AppInstance ID
matches the one on the PhaseApp component.

closes #136