### PR TITLE
fix: remove menu bar from about window (and others)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "Hassan Abdul Ghaffar"
   ],
   "license": "MIT",
-  "homepage": "./",
+  "homepage": "https://graasp.eu/",
   "main": "public/electron.js",
   "keywords": [
     "Graasp Desktop",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/graasp/graasp-desktop"
   },
+  "bugs": {
+    "url": "https://github.com/graasp/graasp-desktop/issues"
+  },
   "scripts": {
     "dev": "yarn react-scripts start",
     "build": "env-cmd -f ./.env react-scripts build",

--- a/public/electron.js
+++ b/public/electron.js
@@ -171,8 +171,8 @@ const generateMenu = () => {
                 frame: true,
               },
               // ? automatically showing info from package.json is nice but not translated into different languages
-              // package_json_dir: path.join(__dirname, '../'),
-              // bug_link_text: 'Report a bug/issue',
+              package_json_dir: path.join(__dirname, '../'),
+              bug_link_text: 'Report a Bug/Issue',
               // ? nor is a close button
               // show_close_button: 'Close',
             });

--- a/public/electron.js
+++ b/public/electron.js
@@ -160,6 +160,21 @@ const generateMenu = () => {
               icon_path: ICON_PATH,
               copyright: 'Copyright © 2019 React',
               product_name: PRODUCT_NAME,
+              use_version_info: false,
+              adjust_window_size: true,
+              win_options: {
+                parent: mainWindow,
+                resizable: false,
+                minimizable: false,
+                maximizable: false,
+                movable: true,
+                frame: true,
+              },
+              // ? automatically showing info from package.json is nice but not translated into different languages
+              // package_json_dir: path.join(__dirname, '../'),
+              // bug_link_text: 'Report a bug/issue',
+              // ? nor is a close button
+              // show_close_button: 'Close',
             });
           },
         },
@@ -228,7 +243,8 @@ const generateMenu = () => {
     },
   ];
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  Menu.setApplicationMenu(null);
+  mainWindow.setMenu(Menu.buildFromTemplate(template));
 };
 
 app.on('ready', async () => {


### PR DESCRIPTION
#134 not fixed as menu bar appears in about window (and any other spawned window) in Linux, and probably Windows.

This patch removes the default window menu and assigns menu to main window only.

It also explicitly sets values for About Window to prevent unexpected future changes and adds bugs url to package.json for completeness/future use.

Generating about window info from package.json would be nice but doesn't support different languages, I guess. Dynamically assign openAboutWindow's "bug_link_text"?