### PR TITLE
fix: make dialogs modal

### DIFF
--- a/public/app/listeners/showDeleteSpacePrompt.js
+++ b/public/app/listeners/showDeleteSpacePrompt.js
@@ -10,7 +10,7 @@ const showDeleteSpacePrompt = mainWindow => () => {
     cancelId: 0,
     message: 'Are you sure you want to delete this space?',
   };
-  dialog.showMessageBox(null, options, respond => {
+  dialog.showMessageBox(mainWindow, options, respond => {
     mainWindow.webContents.send(RESPOND_DELETE_SPACE_PROMPT_CHANNEL, respond);
   });
 };

--- a/public/app/listeners/showExportSpacePrompt.js
+++ b/public/app/listeners/showExportSpacePrompt.js
@@ -7,7 +7,7 @@ const showExportSpacePrompt = mainWindow => (event, spaceTitle) => {
     title: 'Save As',
     defaultPath: `${spaceTitle}.zip`,
   };
-  dialog.showSaveDialog(null, options, filePath => {
+  dialog.showSaveDialog(mainWindow, options, filePath => {
     mainWindow.webContents.send(RESPOND_EXPORT_SPACE_PROMPT_CHANNEL, filePath);
   });
 };

--- a/public/app/listeners/showLoadSpacePrompt.js
+++ b/public/app/listeners/showLoadSpacePrompt.js
@@ -3,7 +3,7 @@ const { dialog } = require('electron');
 const { RESPOND_LOAD_SPACE_PROMPT_CHANNEL } = require('../config/channels');
 
 const showLoadSpacePrompt = mainWindow => (event, options) => {
-  dialog.showOpenDialog(null, options, filePaths => {
+  dialog.showOpenDialog(mainWindow, options, filePaths => {
     mainWindow.webContents.send(RESPOND_LOAD_SPACE_PROMPT_CHANNEL, filePaths);
   });
 };

--- a/public/app/listeners/showSyncSpacePrompt.js
+++ b/public/app/listeners/showSyncSpacePrompt.js
@@ -13,7 +13,7 @@ const showSyncSpacePrompt = mainWindow => () => {
     message:
       'Are you sure you want to sync this space? All user input will be deleted.',
   };
-  dialog.showMessageBox(null, options, respond => {
+  dialog.showMessageBox(mainWindow, options, respond => {
     mainWindow.webContents.send(RESPOND_SYNC_SPACE_PROMPT_CHANNEL, respond);
   });
 };


### PR DESCRIPTION
make os dialogs (open, save, etc) modal so they appear above main window and not as a separate window.

fixes #152