### PR TITLE
feat: add signin and signout actions, refactor dashboard

### DIFF
--- a/public/app/config/config.js
+++ b/public/app/config/config.js
@@ -81,7 +81,7 @@ const VISIBILITIES = {
 
 const DEFAULT_FORMAT = 'v1';
 const ACTIONS_VERBS = {
-  SIGNOUT: 'signout',
+  LOGOUT: 'logout',
 };
 
 module.exports = {

--- a/public/app/config/config.js
+++ b/public/app/config/config.js
@@ -79,6 +79,11 @@ const VISIBILITIES = {
   PRIVATE: 'private',
 };
 
+const DEFAULT_FORMAT = 'v1';
+const ACTIONS_VERBS = {
+  SIGNOUT: 'signout',
+};
+
 module.exports = {
   DEFAULT_LOGGING_LEVEL,
   DEFAULT_PROTOCOL,
@@ -103,4 +108,6 @@ module.exports = {
   DEFAULT_USER_MODE,
   MAX_RECENT_SPACES,
   VISIBILITIES,
+  DEFAULT_FORMAT,
+  ACTIONS_VERBS,
 };

--- a/public/app/db.js
+++ b/public/app/db.js
@@ -10,6 +10,7 @@ const fsPromises = fs.promises;
 
 const SPACES_COLLECTION = 'spaces';
 const ACTIONS_COLLECTION = 'actions';
+const USER_COLLECTION = 'user';
 const USERS_COLLECTION = 'users';
 const APP_INSTANCE_RESOURCES_COLLECTION = 'appInstanceResources';
 const CLASSROOMS_COLLECTION = 'classrooms';
@@ -37,7 +38,7 @@ const bootstrapDatabase = (dbPath = DATABASE_PATH) => {
   db.defaults({
     [SPACES_COLLECTION]: [],
     [USERS_COLLECTION]: [],
-    user: { lang: DEFAULT_LANG },
+    [USER_COLLECTION]: { lang: DEFAULT_LANG },
     [ACTIONS_COLLECTION]: [],
     [APP_INSTANCE_RESOURCES_COLLECTION]: [],
     [CLASSROOMS_COLLECTION]: [],
@@ -47,6 +48,7 @@ const bootstrapDatabase = (dbPath = DATABASE_PATH) => {
 
 module.exports = {
   SPACES_COLLECTION,
+  USER_COLLECTION,
   USERS_COLLECTION,
   APP_INSTANCE_RESOURCES_COLLECTION,
   ACTIONS_COLLECTION,

--- a/public/app/listeners/index.js
+++ b/public/app/listeners/index.js
@@ -49,6 +49,7 @@ const getSpaceInClassroom = require('./getSpaceInClassroom');
 const loadSpaceInClassroom = require('./loadSpaceInClassroom');
 const setActionAccessibility = require('./setActionAccessibility');
 const setActionsAsEnabled = require('./setActionsAsEnabled');
+const windowAllClosed = require('./windowAllClosed');
 
 module.exports = {
   loadSpace,
@@ -101,4 +102,5 @@ module.exports = {
   loadSpaceInClassroom,
   setActionAccessibility,
   setActionsAsEnabled,
+  windowAllClosed,
 };

--- a/public/app/listeners/windowAllClosed.js
+++ b/public/app/listeners/windowAllClosed.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { app } = require('electron');
+const low = require('lowdb');
+const FileSync = require('lowdb/adapters/FileSync');
+const postAction = require('./postAction');
+const { USER_COLLECTION } = require('../db');
+const { DATABASE_PATH, ACTIONS_VERBS } = require('../config/config');
+
+const windowAllClosed = mainWindow => {
+  const adapter = new FileSync(DATABASE_PATH);
+  const db = low(adapter);
+  const user = db.get(USER_COLLECTION).value();
+
+  // post sign out action if user is still connected when quitting the app
+  if (user) {
+    const { id: userId, username, anonymous, geolocation } = user;
+    postAction(mainWindow, db)(null, {
+      userId,
+      verb: ACTIONS_VERBS.LOGOUT,
+      data: { id: userId, username, anonymous },
+      geolocation,
+    });
+  }
+
+  app.quit();
+};
+
+module.exports = windowAllClosed;

--- a/public/electron.js
+++ b/public/electron.js
@@ -15,17 +15,12 @@ const ua = require('universal-analytics');
 const { machineIdSync } = require('node-machine-id');
 const openAboutWindow = require('about-window').default;
 const logger = require('./app/logger');
-const {
-  ensureDatabaseExists,
-  bootstrapDatabase,
-  USER_COLLECTION,
-} = require('./app/db');
+const { ensureDatabaseExists, bootstrapDatabase } = require('./app/db');
 const {
   DATABASE_PATH,
   ICON_PATH,
   PRODUCT_NAME,
   escapeEscapeCharacter,
-  ACTIONS_VERBS,
 } = require('./app/config/config');
 const {
   LOAD_SPACE_CHANNEL,
@@ -131,6 +126,7 @@ const {
   loadSpaceInClassroom,
   setActionAccessibility,
   setActionsAsEnabled,
+  windowAllClosed,
 } = require('./app/listeners');
 const isMac = require('./app/utils/isMac');
 
@@ -606,21 +602,7 @@ app.on('ready', async () => {
   ipcMain.on(SYNC_SPACE_CHANNEL, syncSpace(mainWindow, db));
 });
 
-app.on('window-all-closed', () => {
-  // post sign out action
-  const db = bootstrapDatabase(DATABASE_PATH);
-  const { id: userId, username, anonymous, geolocation } = db
-    .get(USER_COLLECTION)
-    .value();
-  postAction(mainWindow, db)(null, {
-    userId,
-    verb: ACTIONS_VERBS.SIGNOUT,
-    data: { id: userId, username, anonymous },
-    geolocation,
-  });
-
-  app.quit();
-});
+app.on('window-all-closed', () => windowAllClosed(mainWindow));
 
 app.on('activate', () => {
   if (mainWindow === null) {

--- a/src/actions/action.js
+++ b/src/actions/action.js
@@ -1,44 +1,76 @@
 import { POST_ACTION_SUCCEEDED } from '../types';
 import { POST_ACTION_CHANNEL } from '../config/channels';
+import {
+  DEFAULT_ACTIONS_AS_ENABLED,
+  DEFAULT_GEOLOCATION_ENABLED,
+} from '../config/constants';
 
 const postAction = async (
   {
-    userId,
+    userId: actionUserId,
     appInstanceId,
     spaceId,
     subSpaceId,
     format,
     data,
     verb,
-    geolocation,
     visibility,
   } = {},
+  user,
   callback
 ) => () => {
   try {
-    window.ipcRenderer.send(POST_ACTION_CHANNEL, {
-      userId,
-      appInstanceId,
-      spaceId,
-      subSpaceId,
-      format,
-      data,
-      verb,
+    const mutableUser = user.toJS();
+    const {
+      id,
+      settings: {
+        actionsEnabled = DEFAULT_ACTIONS_AS_ENABLED,
+        geolocationEnabled = DEFAULT_GEOLOCATION_ENABLED,
+      },
       geolocation,
-      visibility,
-    });
+    } = mutableUser;
 
-    window.ipcRenderer.once(
-      `${POST_ACTION_CHANNEL}_${appInstanceId}`,
-      async (event, response) => {
-        callback({
-          // have to include the appInstanceId to avoid broadcasting
-          appInstanceId,
-          type: POST_ACTION_SUCCEEDED,
-          payload: response,
-        });
+    if (actionsEnabled) {
+      // get user id
+      let userId = actionUserId;
+      if (!actionUserId) {
+        userId = id;
       }
-    );
+
+      // add geolocation to action if enabled
+      let geolocationLatLong = null;
+      if (geolocationEnabled) {
+        const { latitude, longitude } = geolocation;
+        geolocationLatLong = { ll: [latitude, longitude] };
+      }
+
+      window.ipcRenderer.send(POST_ACTION_CHANNEL, {
+        userId,
+        appInstanceId,
+        spaceId,
+        subSpaceId,
+        format,
+        data,
+        verb,
+        geolocation: geolocationLatLong,
+        visibility,
+      });
+
+      // if action from app, wait in app channel
+      if (appInstanceId) {
+        window.ipcRenderer.once(
+          `${POST_ACTION_CHANNEL}_${appInstanceId}`,
+          async (event, response) => {
+            callback({
+              // have to include the appInstanceId to avoid broadcasting
+              appInstanceId,
+              type: POST_ACTION_SUCCEEDED,
+              payload: response,
+            });
+          }
+        );
+      }
+    }
   } catch (err) {
     // do nothing
   }

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -20,6 +20,8 @@ import {
 } from '../config/channels';
 import { createFlag } from './common';
 import { ERROR_GENERAL } from '../config/errors';
+import { postAction } from './action';
+import { ACTION_VERBS } from '../config/constants';
 
 const flagSigningIn = createFlag(FLAG_SIGNING_IN);
 const flagSigningOut = createFlag(FLAG_SIGNING_OUT);
@@ -37,6 +39,7 @@ const signIn = async ({ username, anonymous }) => async dispatch => {
           type: SIGN_IN_SUCCEEDED,
           payload: user,
         });
+        // action is sent in sign in redirection
       }
       dispatch(flagSigningIn(false));
     });
@@ -46,7 +49,7 @@ const signIn = async ({ username, anonymous }) => async dispatch => {
   }
 };
 
-const signOut = () => dispatch => {
+const signOut = user => dispatch => {
   try {
     dispatch(flagSigningOut(true));
     window.ipcRenderer.send(SIGN_OUT_CHANNEL);
@@ -58,6 +61,18 @@ const signOut = () => dispatch => {
           type: SIGN_OUT_SUCCEEDED,
           payload: response,
         });
+        const username = user.get('username');
+        const id = user.get('id');
+        const anonymous = user.get('anonymous');
+        dispatch(
+          postAction(
+            {
+              verb: ACTION_VERBS.SIGNOUT,
+              data: { username, id, anonymous },
+            },
+            user
+          )
+        );
       }
       dispatch(flagSigningOut(false));
     });

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -67,7 +67,7 @@ const signOut = user => dispatch => {
         dispatch(
           postAction(
             {
-              verb: ACTION_VERBS.SIGNOUT,
+              verb: ACTION_VERBS.LOGOUT,
               data: { username, id, anonymous },
             },
             user

--- a/src/components/common/MainMenu.js
+++ b/src/components/common/MainMenu.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
@@ -58,6 +59,11 @@ export class MainMenu extends Component {
     location: PropTypes.shape({ pathname: PropTypes.string.isRequired })
       .isRequired,
     userMode: PropTypes.oneOf(Object.values(USER_MODES)).isRequired,
+    user: PropTypes.instanceOf(Map),
+  };
+
+  static defaultProps = {
+    user: Map(),
   };
 
   handleClick = path => {
@@ -74,12 +80,12 @@ export class MainMenu extends Component {
 
   handleSignOut() {
     // pathname inside location matches the path in url
-    const { location: { pathname } = {}, dispatchSignOut } = this.props;
+    const { location: { pathname } = {}, dispatchSignOut, user } = this.props;
     if (pathname) {
       sessionStorage.setItem('redirect', pathname);
     }
 
-    dispatchSignOut();
+    dispatchSignOut(user);
   }
 
   renderSignOut() {
@@ -342,6 +348,7 @@ const mapStateToProps = ({ authentication }) => ({
   developerMode: authentication.getIn(['user', 'settings', 'developerMode']),
   userMode: authentication.getIn(['user', 'settings', 'userMode']),
   activity: Boolean(authentication.getIn(['current', 'activity']).size),
+  user: authentication.get('user'),
 });
 const mapDispatchToProps = {
   dispatchSignOut: signOut,

--- a/src/components/dashboard/ActionBarChart.js
+++ b/src/components/dashboard/ActionBarChart.js
@@ -55,19 +55,11 @@ class ActionBarChart extends PureComponent {
     spaces: [],
   };
 
-  render() {
-    const { spaces, theme, t, actions } = this.props;
+  renderChart = actions => {
+    const { spaces, theme, t } = this.props;
     const {
       palette: { primary, type },
     } = theme;
-
-    if (!spaces || !actions) {
-      return <Loader />;
-    }
-
-    if (_.isEmpty(spaces) || _.isEmpty(actions)) {
-      return <p>{t('No action has been recorded.')}</p>;
-    }
 
     const data =
       // group actions by space id
@@ -84,38 +76,56 @@ class ActionBarChart extends PureComponent {
         });
 
     return (
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          width="100%"
+          height="100%"
+          data={data}
+          margin={{
+            top: 5,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="space" />
+          <YAxis
+            label={{
+              value: t('Action Count'),
+              angle: -90,
+              position: 'insideLeft',
+            }}
+          />
+          <Tooltip />
+          <Legend />
+          <Bar name={t('Action Count')} dataKey="count" fill={primary[type]} />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  render() {
+    const { spaces, t, actions } = this.props;
+
+    if (!spaces || !actions) {
+      return <Loader />;
+    }
+
+    // remove actions unrelated to spaces
+    const actionsWithDefinedSpaceId = actions.filter(({ spaceId }) => spaceId);
+
+    const content =
+      _.isEmpty(spaces) || _.isEmpty(actionsWithDefinedSpaceId) ? (
+        <p>{t('No action has been recorded.')}</p>
+      ) : (
+        this.renderChart(actionsWithDefinedSpaceId)
+      );
+
+    return (
       <>
         <Typography variant="h5">{t('Action Count Per Space')}</Typography>
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            width="100%"
-            height="100%"
-            data={data}
-            margin={{
-              top: 5,
-              right: 30,
-              left: 20,
-              bottom: 5,
-            }}
-          >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="space" />
-            <YAxis
-              label={{
-                value: t('Action Count'),
-                angle: -90,
-                position: 'insideLeft',
-              }}
-            />
-            <Tooltip />
-            <Legend />
-            <Bar
-              name={t('Action Count')}
-              dataKey="count"
-              fill={primary[type]}
-            />
-          </BarChart>
-        </ResponsiveContainer>
+        {content}
       </>
     );
   }

--- a/src/components/dashboard/ActionBarChart.js
+++ b/src/components/dashboard/ActionBarChart.js
@@ -14,7 +14,6 @@ import {
 } from 'recharts';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core';
-import Loader from '../common/Loader';
 import Styles from '../../Styles';
 
 class ActionBarChart extends PureComponent {
@@ -107,10 +106,6 @@ class ActionBarChart extends PureComponent {
 
   render() {
     const { spaces, t, actions } = this.props;
-
-    if (!spaces || !actions) {
-      return <Loader />;
-    }
 
     // remove actions unrelated to spaces
     const actionsWithDefinedSpaceId = actions.filter(({ spaceId }) => spaceId);

--- a/src/components/developer/DatabaseEditor.js
+++ b/src/components/developer/DatabaseEditor.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import ReactJson from 'react-json-view';
 import PropTypes from 'prop-types';
+import { Map } from 'immutable';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import { withTranslation } from 'react-i18next';
@@ -21,9 +22,9 @@ export class DatabaseEditor extends Component {
     dispatchGetDatabase: PropTypes.func.isRequired,
     dispatchSetDatabase: PropTypes.func.isRequired,
     database: PropTypes.shape({
-      user: PropTypes.object,
       spaces: PropTypes.array,
     }),
+    user: PropTypes.instanceOf(Map).isRequired,
     dispatchSignOut: PropTypes.func.isRequired,
   };
 
@@ -42,11 +43,11 @@ export class DatabaseEditor extends Component {
   };
 
   handleUseSampleDatabase = () => {
-    const { dispatchSetDatabase, dispatchSignOut } = this.props;
+    const { dispatchSetDatabase, dispatchSignOut, user } = this.props;
     dispatchSetDatabase(SampleDatabase);
 
     // sign out to force authenticate with existing user
-    dispatchSignOut();
+    dispatchSignOut(user);
   };
 
   render() {
@@ -84,8 +85,9 @@ export class DatabaseEditor extends Component {
   }
 }
 
-const mapStateToProps = ({ Developer }) => ({
+const mapStateToProps = ({ Developer, authentication }) => ({
   database: Developer.get('database'),
+  user: authentication.get('user'),
 });
 
 const mapDispatchToProps = {

--- a/src/components/phase/PhaseApp.js
+++ b/src/components/phase/PhaseApp.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Map } from 'immutable';
 import Qs from 'qs';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -58,8 +59,7 @@ class PhaseApp extends Component {
     appInstance: PropTypes.shape({
       id: PropTypes.string.isRequired,
     }),
-    geolocation: PropTypes.instanceOf(Map),
-    geolocationEnabled: PropTypes.bool.isRequired,
+    user: PropTypes.instanceOf(Map).isRequired,
     actionsEnabled: PropTypes.bool.isRequired,
   };
 
@@ -69,7 +69,6 @@ class PhaseApp extends Component {
     appInstance: null,
     name: 'Image',
     lang: DEFAULT_LANGUAGE,
-    geolocation: null,
     userId: null,
   };
 
@@ -116,9 +115,7 @@ class PhaseApp extends Component {
         dispatchGetAppInstance,
         appInstance,
         dispatchPostAction,
-        geolocation,
-        geolocationEnabled,
-        actionsEnabled,
+        user,
       } = this.props;
 
       // get app instance id in message
@@ -141,16 +138,7 @@ class PhaseApp extends Component {
           case GET_APP_INSTANCE:
             return dispatchGetAppInstance(payload, this.postMessage);
           case POST_ACTION: {
-            if (actionsEnabled) {
-              // add geolocation to action if enabled
-              payload.geolocation = null;
-              if (geolocationEnabled) {
-                const { latitude, longitude } = geolocation.getIn(['coords']);
-                payload.geolocation = { ll: [latitude, longitude] };
-              }
-              return dispatchPostAction(payload, this.postMessage);
-            }
-            break;
+            return dispatchPostAction(payload, user, this.postMessage);
           }
           default:
             return false;
@@ -315,6 +303,7 @@ const mapStateToProps = ({ authentication, Space }) => ({
     'geolocationEnabled',
   ]),
   userId: authentication.getIn(['user', 'id']),
+  user: authentication.getIn(['user']),
   actionsEnabled: authentication.getIn(['user', 'settings', 'actionsEnabled']),
 });
 

--- a/src/components/signin/SignInScreen.js
+++ b/src/components/signin/SignInScreen.js
@@ -118,7 +118,7 @@ class SignInScreen extends Component {
       const anonymous = user.get('anonymous');
       const id = user.get('id');
       dispatchPostAction(
-        { verb: ACTION_VERBS.SIGNIN, data: { username, id, anonymous } },
+        { verb: ACTION_VERBS.LOGIN, data: { username, id, anonymous } },
         user
       );
 

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -114,3 +114,8 @@ export const ROWS_PER_PAGE_OPTIONS = [5, 10, 25];
 export const TABLE_ROW_HEIGHT = 43;
 
 export const DRAWER_HEADER_HEIGHT = 55;
+
+export const ACTION_VERBS = {
+  SIGNIN: 'signin',
+  SIGNOUT: 'signout',
+};

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -116,6 +116,6 @@ export const TABLE_ROW_HEIGHT = 43;
 export const DRAWER_HEADER_HEIGHT = 55;
 
 export const ACTION_VERBS = {
-  SIGNIN: 'signin',
-  SIGNOUT: 'signout',
+  LOGIN: 'login',
+  LOGOUT: 'logout',
 };


### PR DESCRIPTION
This PR adds two actions with verb `signin` and `signout` when the user signs in or out. Actions are also saved when the application automatically signs in, or when the user signs out by closing the whole app.