### PR TITLE
fix: visit a space just after delete

### DIFF
--- a/public/app/listeners/getAppUpgrade.js
+++ b/public/app/listeners/getAppUpgrade.js
@@ -7,6 +7,11 @@ const {
 const { ERROR_GENERAL } = require('../config/errors');
 
 const getAppUpgrade = (mainWindow) => async () => {
+  // disable app upgrade on test
+  if (process.env.NODE_ENV === 'test') {
+    mainWindow.webContents.send(GET_APP_UPGRADE_CHANNEL, false);
+  }
+
   // app update
   autoUpdater.logger = logger;
   autoUpdater.autoDownload = false;

--- a/src/actions/space.js
+++ b/src/actions/space.js
@@ -97,7 +97,7 @@ const createGetLocalSpace = async (
   type,
   flagType,
   showError = true
-) => async dispatch => {
+) => async (dispatch) => {
   const flagGettingSpace = createFlag(flagType);
   try {
     dispatch(flagGettingSpace(true));
@@ -123,14 +123,12 @@ const createGetLocalSpace = async (
   }
 };
 
-const getLocalSpace = payload =>
+const getLocalSpace = (payload) =>
   createGetLocalSpace(payload, GET_SPACE_SUCCEEDED, FLAG_GETTING_SPACE);
 
-const createGetRemoteSpace = async (
-  { id },
-  type,
-  flagType
-) => async dispatch => {
+const createGetRemoteSpace = async ({ id }, type, flagType) => async (
+  dispatch
+) => {
   const flagGettingSpace = createFlag(flagType);
   try {
     dispatch(flagGettingSpace(true));
@@ -174,10 +172,10 @@ const createGetRemoteSpace = async (
   }
 };
 
-const getRemoteSpace = payload =>
+const getRemoteSpace = (payload) =>
   createGetRemoteSpace(payload, GET_SPACE_SUCCEEDED, FLAG_GETTING_SPACE);
 
-const getSpaces = () => dispatch => {
+const getSpaces = () => (dispatch) => {
   dispatch(flagGettingSpaces(true));
   window.ipcRenderer.send(GET_SPACES_CHANNEL);
   // create listener
@@ -191,7 +189,7 @@ const getSpaces = () => dispatch => {
   });
 };
 
-const saveSpace = async ({ space }) => async dispatch => {
+const saveSpace = async ({ space }) => async (dispatch) => {
   try {
     dispatch(flagSavingSpace(true));
 
@@ -246,14 +244,14 @@ const saveSpace = async ({ space }) => async dispatch => {
   }
 };
 
-const clearSpace = () => dispatch => {
+const clearSpace = () => (dispatch) => {
   dispatch(clearPhase());
   return dispatch({
     type: CLEAR_SPACE,
   });
 };
 
-const deleteSpace = ({ id }) => dispatch => {
+const deleteSpace = ({ id }, onSuccess) => (dispatch) => {
   // show confirmation prompt
   const buttons = [i18n.t('Cancel'), i18n.t('Delete')];
   window.ipcRenderer.send(SHOW_DELETE_SPACE_PROMPT_CHANNEL, {
@@ -276,6 +274,9 @@ const deleteSpace = ({ id }) => dispatch => {
         i18n.t(ERROR_DELETING_MESSAGE)
       );
     } else {
+      // eslint-disable-next-line no-unused-expressions
+      onSuccess?.();
+
       // update saved spaces in state
       dispatch(getSpaces());
 
@@ -299,7 +300,7 @@ const deleteSpace = ({ id }) => dispatch => {
   });
 };
 
-const clearUserInput = async ({ spaceId, userId }) => async dispatch => {
+const clearUserInput = async ({ spaceId, userId }) => async (dispatch) => {
   try {
     // show confirmation prompt
     const buttons = [i18n.t('Cancel'), i18n.t('Clear')];
@@ -346,7 +347,7 @@ const clearUserInput = async ({ spaceId, userId }) => async dispatch => {
   }
 };
 
-const getSpace = ({ id, saved = false, user }) => dispatch => {
+const getSpace = ({ id, saved = false, user }) => (dispatch) => {
   // only get the space from the api if not saved
   if (!saved) {
     dispatch(getRemoteSpace({ id }));
@@ -359,7 +360,7 @@ const getSpacesNearby = async ({
   latitude,
   longitude,
   radius = DEFAULT_RADIUS,
-}) => async dispatch => {
+}) => async (dispatch) => {
   try {
     dispatch(flagGettingSpacesNearby(true));
 
@@ -385,7 +386,7 @@ const getSpacesNearby = async ({
   }
 };
 
-const setSearchQuery = async payload => async dispatch => {
+const setSearchQuery = async (payload) => async (dispatch) => {
   dispatch({
     type: SET_SPACE_SEARCH_QUERY_SUCCEEDED,
     payload,

--- a/src/components/VisitSpace.js
+++ b/src/components/VisitSpace.js
@@ -57,7 +57,7 @@ class VisitSpace extends Component {
     }).isRequired,
     activity: PropTypes.bool,
     history: PropTypes.shape({
-      replace: PropTypes.func.isRequired,
+      push: PropTypes.func.isRequired,
     }).isRequired,
   };
 
@@ -65,7 +65,7 @@ class VisitSpace extends Component {
     activity: false,
   };
 
-  handleChangeSpaceId = event => {
+  handleChangeSpaceId = (event) => {
     const spaceId = event.target.value;
     this.setState({ spaceId });
   };
@@ -81,13 +81,13 @@ class VisitSpace extends Component {
       return toastr.error(t(ERROR_MESSAGE_HEADER), t(INVALID_SPACE_ID_OR_URL));
     }
     if (id && id !== '') {
-      const { replace } = history;
-      return replace(`/space/${id}`);
+      const { push } = history;
+      return push(`/space/${id}`);
     }
     return false;
   };
 
-  handleKeyPress = event => {
+  handleKeyPress = (event) => {
     if (event.key === 'Enter') {
       this.handleClick();
     }

--- a/src/components/space/DeleteButton.js
+++ b/src/components/space/DeleteButton.js
@@ -20,11 +20,16 @@ class DeleteButton extends Component {
     }).isRequired,
     dispatchDeleteSpace: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
+    onSuccess: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onSuccess: null,
   };
 
   handleDelete = () => {
-    const { spaceId: id, dispatchDeleteSpace } = this.props;
-    dispatchDeleteSpace({ id });
+    const { spaceId: id, dispatchDeleteSpace, onSuccess } = this.props;
+    dispatchDeleteSpace({ id }, onSuccess);
   };
 
   render() {

--- a/src/components/space/SpaceGrid.js
+++ b/src/components/space/SpaceGrid.js
@@ -149,7 +149,7 @@ class SpaceGrid extends Component {
 
     const MediaCards = [];
 
-    columnWrapper.items.forEach(column => {
+    columnWrapper.items.forEach((column) => {
       MediaCards.push(
         <div
           style={{
@@ -173,9 +173,8 @@ class SpaceGrid extends Component {
   }
 }
 
-const mapStateToProps = ({ authentication, Space }) => ({
+const mapStateToProps = ({ authentication }) => ({
   folder: authentication.getIn(['current', 'folder']),
-  deleted: Space.getIn(['current', 'deleted']),
 });
 
 const mapDispatchToProps = {

--- a/src/components/space/SpaceHeader.js
+++ b/src/components/space/SpaceHeader.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import clsx from 'clsx';
 import MenuIcon from '@material-ui/icons/Menu';
 import AppBar from '@material-ui/core/AppBar/AppBar';
@@ -48,6 +49,9 @@ class SpaceHeader extends Component {
     dispatchSaveSpace: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired,
     userMode: PropTypes.oneOf(Object.values(USER_MODES)).isRequired,
+    history: PropTypes.shape({
+      goBack: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   handleSave = () => {
@@ -93,10 +97,16 @@ class SpaceHeader extends Component {
   }
 
   renderDeleteButton() {
-    const { space } = this.props;
+    const {
+      space,
+      history: { goBack },
+    } = this.props;
     const { saved, id } = space;
     if (saved) {
-      return <DeleteButton spaceId={id} />;
+      const onSuccess = () => {
+        goBack();
+      };
+      return <DeleteButton spaceId={id} onSuccess={onSuccess} />;
     }
     return null;
   }
@@ -203,9 +213,7 @@ class SpaceHeader extends Component {
 }
 
 const mapStateToProps = ({ Space, authentication }) => ({
-  space: Space.get('current')
-    .get('content')
-    .toJS(),
+  space: Space.get('current').get('content').toJS(),
   userMode: authentication.getIn(['user', 'settings', 'userMode']),
 });
 
@@ -224,4 +232,4 @@ const StyledComponent = withStyles(Styles, { withTheme: true })(
 
 const TranslatedComponent = withTranslation()(StyledComponent);
 
-export default TranslatedComponent;
+export default withRouter(TranslatedComponent);

--- a/src/components/space/SpaceScreen.js
+++ b/src/components/space/SpaceScreen.js
@@ -29,7 +29,6 @@ import {
 } from '../../actions';
 import './SpaceScreen.css';
 import Styles from '../../Styles';
-import { HOME_PATH } from '../../config/paths';
 import SpaceHeader from './SpaceHeader';
 import SpaceNotFound from './SpaceNotFound';
 import MainMenu from '../common/MainMenu';
@@ -60,7 +59,6 @@ class SpaceScreen extends Component {
     dispatchGetSpace: PropTypes.func.isRequired,
     dispatchClearSpace: PropTypes.func.isRequired,
     activity: PropTypes.bool.isRequired,
-    deleted: PropTypes.bool.isRequired,
     classes: PropTypes.shape({
       root: PropTypes.string.isRequired,
       appBar: PropTypes.string.isRequired,
@@ -82,7 +80,7 @@ class SpaceScreen extends Component {
     }).isRequired,
     history: PropTypes.shape({
       length: PropTypes.number.isRequired,
-      replace: PropTypes.func.isRequired,
+      goBack: PropTypes.func.isRequired,
     }).isRequired,
     recentSpaces: PropTypes.instanceOf(ImmList).isRequired,
     dispatchSetSpaceAsRecent: PropTypes.func.isRequired,
@@ -104,18 +102,8 @@ class SpaceScreen extends Component {
 
   componentDidUpdate() {
     const { selected } = this.state;
-    const {
-      deleted,
-      phase,
-      history: { replace },
-      space,
-      recentSpaces,
-      dispatchSetSpaceAsRecent,
-    } = this.props;
-    // redirect to home if space is deleted
-    if (deleted) {
-      replace(HOME_PATH);
-    } else if (selected !== -1 && (!phase || phase.isEmpty())) {
+    const { phase, space, recentSpaces, dispatchSetSpaceAsRecent } = this.props;
+    if (selected !== -1 && (!phase || phase.isEmpty())) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ selected: -1 });
     }
@@ -145,7 +133,7 @@ class SpaceScreen extends Component {
     this.setState({ openDrawer: false });
   };
 
-  handlePhaseClicked = i => {
+  handlePhaseClicked = (i) => {
     const { dispatchSelectPhase, space } = this.props;
     const phases = space.get('phases');
     dispatchSelectPhase(phases[i]);
@@ -251,12 +239,9 @@ class SpaceScreen extends Component {
 
 const mapStateToProps = ({ Space, Phase, authentication }) => ({
   space: Space.get('current').get('content'),
-  open: Space.get('current')
-    .get('menu')
-    .get('open'),
+  open: Space.get('current').get('menu').get('open'),
   phase: Phase.get('current').get('content'),
   activity: Boolean(Space.getIn(['current', 'activity']).size),
-  deleted: Space.get('current').get('deleted'),
   recentSpaces: authentication.getIn(['user', 'recentSpaces']),
 });
 

--- a/src/components/space/SpaceScreen.js
+++ b/src/components/space/SpaceScreen.js
@@ -17,7 +17,6 @@ import MenuItem from '@material-ui/core/MenuItem/MenuItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText/ListItemText';
 import { withStyles } from '@material-ui/core';
-import { withRouter } from 'react-router';
 import Loader from '../common/Loader';
 import PhaseComponent from '../phase/Phase';
 import {
@@ -77,10 +76,6 @@ class SpaceScreen extends Component {
     }).isRequired,
     location: PropTypes.shape({
       search: PropTypes.string.isRequired,
-    }).isRequired,
-    history: PropTypes.shape({
-      length: PropTypes.number.isRequired,
-      goBack: PropTypes.func.isRequired,
     }).isRequired,
     recentSpaces: PropTypes.instanceOf(ImmList).isRequired,
     dispatchSetSpaceAsRecent: PropTypes.func.isRequired,
@@ -262,4 +257,4 @@ const StyledComponent = withStyles(Styles, { withTheme: true })(
   ConnectedComponent
 );
 
-export default withRouter(StyledComponent);
+export default StyledComponent;

--- a/src/components/space/SyncAdvancedScreen.js
+++ b/src/components/space/SyncAdvancedScreen.js
@@ -16,7 +16,6 @@ import Loader from '../common/Loader';
 import { clearSpacesForSync } from '../../actions';
 import './SpaceScreen.css';
 import Styles from '../../Styles';
-import { HOME_PATH } from '../../config/paths';
 import SpaceNotFound from './SpaceNotFound';
 import { SYNC_SPACE_PROPERTIES } from '../../config/constants';
 import SyncCancelButton from './sync/SyncCancelButton';
@@ -76,17 +75,6 @@ class SyncAdvancedScreen extends Component {
     }).isRequired,
     t: PropTypes.func.isRequired,
   };
-
-  componentDidUpdate() {
-    const {
-      localSpace: { deleted },
-      history: { replace },
-    } = this.props;
-    // redirect to home if space is deleted
-    if (deleted) {
-      replace(HOME_PATH);
-    }
-  }
 
   componentWillUnmount() {
     const { dispatchClearSpaces } = this.props;

--- a/src/components/space/SyncScreen.js
+++ b/src/components/space/SyncScreen.js
@@ -27,7 +27,7 @@ import Styles from '../../Styles';
 import Loader from '../common/Loader';
 import { DEFAULT_SYNC_MODE, SYNC_MODES } from '../../config/constants';
 
-const styles = theme => ({
+const styles = (theme) => ({
   ...Styles(theme),
   centerText: {
     textAlign: 'center',
@@ -53,7 +53,6 @@ class SyncScreen extends Component {
       id: PropTypes.string,
       description: PropTypes.string,
       name: PropTypes.string,
-      deleted: PropTypes.bool,
     }),
     remoteSpace: ImmutablePropTypes.contains({
       id: PropTypes.string,

--- a/src/components/space/SyncVisualScreen.js
+++ b/src/components/space/SyncVisualScreen.js
@@ -42,7 +42,6 @@ import {
   selectPhaseForSync,
 } from '../../actions';
 import Styles from '../../Styles';
-import { HOME_PATH } from '../../config/paths';
 import SpaceNotFound from './SpaceNotFound';
 import Text from '../common/Text';
 import SyncPhases from './sync/SyncPhases';
@@ -65,7 +64,7 @@ import {
 
 const { ADDED, REMOVED, UPDATED } = SYNC_CHANGES;
 
-const styles = theme => ({
+const styles = (theme) => ({
   ...Styles(theme),
   syncWrapper: {
     padding: '0 20px',
@@ -124,7 +123,6 @@ class SyncScreen extends Component {
       replace: PropTypes.func.isRequired,
     }).isRequired,
     t: PropTypes.func.isRequired,
-    deleted: PropTypes.bool.isRequired,
     folder: PropTypes.string.isRequired,
   };
 
@@ -183,17 +181,6 @@ class SyncScreen extends Component {
     }
   }
 
-  componentDidUpdate() {
-    const {
-      deleted,
-      history: { replace },
-    } = this.props;
-    // redirect to home if space is deleted
-    if (deleted) {
-      replace(HOME_PATH);
-    }
-  }
-
   componentWillUnmount() {
     const { dispatchClearSpaces, dispatchClearPhases } = this.props;
     dispatchClearSpaces();
@@ -215,7 +202,7 @@ class SyncScreen extends Component {
     this.setState({ openDrawer: false });
   };
 
-  handlePhaseClicked = i => {
+  handlePhaseClicked = (i) => {
     const { dispatchSelectPhase } = this.props;
     const { syncPhases } = this.state;
 
@@ -358,7 +345,7 @@ class SyncScreen extends Component {
             lChanges.length + rChanges.length
         )
         // return whether one of the element has a change
-        .some(nbChange => nbChange > 0);
+        .some((nbChange) => nbChange > 0);
 
     return (
       <MenuItem

--- a/src/components/space/sync/SyncAdvancedSwitch.js
+++ b/src/components/space/sync/SyncAdvancedSwitch.js
@@ -15,7 +15,7 @@ import {
   FORM_CONTROL_MIN_WIDTH,
 } from '../../../config/constants';
 
-const styles = theme => ({
+const styles = (theme) => ({
   formControl: {
     margin: theme.spacing(),
     minWidth: FORM_CONTROL_MIN_WIDTH,

--- a/src/components/space/sync/SyncPhaseItem.js
+++ b/src/components/space/sync/SyncPhaseItem.js
@@ -17,7 +17,7 @@ import PhaseVideo from '../../phase/PhaseVideo';
 
 // prop types gets confused when dealing with helper renderers
 // eslint-disable-next-line react/prop-types
-const renderResource = item => {
+const renderResource = (item) => {
   const { id, idx, mimeType, content, asset, url, name, classNames } = item;
   if (mimeType === TEXT) {
     return (

--- a/test/spaces/visitSpace.test.js
+++ b/test/spaces/visitSpace.test.js
@@ -467,7 +467,8 @@ describe('Visit Space Scenarios', function () {
       } = space;
       it(
         `Visit space ${name} (${id})`,
-        mochaAsync(async () => {
+        mochaAsync(async function () {
+          this.retries(2);
           const { client } = app;
 
           await visitSpaceById(client, id);

--- a/test/spaces/visitSpace.test.js
+++ b/test/spaces/visitSpace.test.js
@@ -13,6 +13,7 @@ import {
   menuGoToVisitSpace,
   expectElementToExist,
   removePathSeparators,
+  menuGoToSavedSpaces,
 } from '../utils';
 import { closeApplication, createApplication } from '../application';
 import {
@@ -36,6 +37,8 @@ import {
   buildSpaceCardDescriptionId,
   TOOLS_BUTTON_CLASS,
   TOOLS_CONTENT_PANE_ID,
+  VISIT_MAIN_ID,
+  SAVED_SPACES_MAIN_ID,
 } from '../../src/config/selectors';
 import { hasMath } from '../../src/utils/math';
 import { SPACE_ATOMIC_STRUCTURE, SPACE_APOLLO_11 } from '../fixtures/spaces';
@@ -48,6 +51,7 @@ import {
   LOAD_PHASE_PAUSE,
   OPEN_TOOLS_PAUSE,
   APPS_FOLDER,
+  DELETE_SPACE_PAUSE,
 } from '../constants';
 import { USER_GRAASP } from '../fixtures/users';
 import { USER_MODES, DEFAULT_USER_MODE } from '../../src/config/constants';
@@ -446,28 +450,79 @@ describe('Visit Space Scenarios', function () {
     return closeApplication(app);
   });
 
-  beforeEach(
-    mochaAsync(async () => {
-      app = await createApplication();
-      globalUser = USER_GRAASP;
-      await userSignIn(app.client, globalUser);
-    })
-  );
+  describe('Visit a space just after delete', () => {
+    beforeEach(
+      mochaAsync(async () => {
+        app = await createApplication();
+        globalUser = USER_GRAASP;
+        await userSignIn(app.client, globalUser);
+      })
+    );
 
-  const spaces = [SPACE_APOLLO_11, SPACE_ATOMIC_STRUCTURE];
+    const spaces = [SPACE_APOLLO_11, SPACE_ATOMIC_STRUCTURE];
 
-  spaces.forEach(function (space) {
-    const {
-      space: { id, name },
-    } = space;
+    spaces.forEach(function (space) {
+      const {
+        space: { id, name },
+      } = space;
+      it(
+        `Visit space ${name} (${id})`,
+        mochaAsync(async () => {
+          const { client } = app;
+
+          await visitSpaceById(client, id);
+
+          await hasPreviewSpaceLayout(client, space, globalUser);
+        })
+      );
+    });
+  });
+
+  describe('Visit a space just after delete', () => {
+    beforeEach(
+      mochaAsync(async () => {
+        app = await createApplication({ showMessageDialogResponse: 1 });
+        globalUser = USER_GRAASP;
+        await userSignIn(app.client, globalUser);
+      })
+    );
+
     it(
-      `Visit space ${name} (${id})`,
+      'Visit a space just after delete from card',
       mochaAsync(async () => {
         const { client } = app;
+        const {
+          space: { id },
+        } = SPACE_ATOMIC_STRUCTURE;
+        await visitAndSaveSpaceById(client, id);
+        await menuGoToSavedSpaces(client);
 
+        const deleteButton = await client.$(
+          `#${buildSpaceCardId(id)} .${SPACE_DELETE_BUTTON_CLASS}`
+        );
+        await deleteButton.click();
+        await client.pause(DELETE_SPACE_PAUSE);
+
+        await expectElementToExist(client, `#${SAVED_SPACES_MAIN_ID}`);
         await visitSpaceById(client, id);
+      })
+    );
 
-        await hasPreviewSpaceLayout(client, space, globalUser);
+    it(
+      'Visit a space just after delete from space',
+      mochaAsync(async () => {
+        const { client } = app;
+        const {
+          space: { id },
+        } = SPACE_ATOMIC_STRUCTURE;
+        await visitAndSaveSpaceById(client, id);
+
+        const deleteButton = await client.$(`.${SPACE_DELETE_BUTTON_CLASS}`);
+        await deleteButton.click();
+        await client.pause(DELETE_SPACE_PAUSE);
+
+        await expectElementToExist(client, `#${VISIT_MAIN_ID}`);
+        await visitSpaceById(client, id);
       })
     );
   });


### PR DESCRIPTION
close #352 

I added more details in the issue itself. In this PR I got rid of the `deleted` property and used `onSuccess` callback when deleting a space to redirect the page. 